### PR TITLE
Extracts logging into its own module

### DIFF
--- a/lib/gingr.rb
+++ b/lib/gingr.rb
@@ -5,6 +5,7 @@ require_relative 'gingr/config'
 require_relative 'gingr/data_handler'
 require_relative 'gingr/geoserver_publisher'
 require_relative 'gingr/import_util'
+require_relative 'gingr/logging'
 require_relative 'gingr/solr_indexer'
 require_relative 'gingr/watcher'
 

--- a/lib/gingr/cli.rb
+++ b/lib/gingr/cli.rb
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 require 'thor'
-require_relative 'config'
 require_relative 'import_util'
 require_relative 'watcher'
 
 module Gingr
   class Cli < Thor
-    include Config
     include ImportUtil
+    include Logging
 
     Thor.check_unknown_options!
 
@@ -47,7 +46,7 @@ module Gingr
       solr_url = options[:solr_url] || ENV.fetch('SOLR_URL', nil)
       ImportUtil.index_solr_from_dir(dir_path, solr_url, reference_urls)
       txt = "all json files under '#{dir_path}' and subdirectories have been indexed to solr #{solr_url} successfully"
-      Config.logger.info(txt)
+      logger.info(txt)
     end
 
     desc 'geoserver', 'publish a giving shapefile or GeoTIFF file to a geoserver'
@@ -63,7 +62,7 @@ module Gingr
       url ||= options[:is_public] ? ENV.fetch('GEOSERVER_URL', nil) : ENV.fetch('GEOSERVER_SECURE_URL', nil)
       publisher = GeoserverPublisher.new(url)
       publisher.update(filename)
-      Config.logger.info("'#{filename}' - published to geoserver #{url} successfully")
+      logger.info("'#{filename}' - published to geoserver #{url} successfully")
     end
 
     desc 'unpack',
@@ -102,7 +101,7 @@ module Gingr
 
       geofile_names = unpacked[:geofile_name_hash]
       ImportUtil.publish_geoservers(geofile_names, options)
-      Config.logger.info("#{zipfile} - all imported")
+      logger.info("#{zipfile} - all imported")
     end
 
     desc 'geoserver_workspace', 'create a workspace in a geoserver'
@@ -116,7 +115,7 @@ module Gingr
       url ||= options[:is_public] ? ENV.fetch('GEOSERVER_URL', nil) : ENV.fetch('GEOSERVER_SECURE_URL', nil)
       publisher = GeoserverPublisher.new(url)
       publisher.create_workspace(name)
-      Config.logger.info("geoserver workspace '#{name}' - created successfully")
+      logger.info("geoserver workspace '#{name}' - created successfully")
     end
 
     def self.exit_on_failure?

--- a/lib/gingr/config.rb
+++ b/lib/gingr/config.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
-require 'berkeley_library/logging'
 
-# Gingr
 module Gingr
-  # config info
   module Config
-    # value: urls poplated for reference field in pre-ingestion tool
+    # value: urls populated for reference field in pre-ingestion tool
     @reference_urls = {
       geoserver_secure_url: 'https://geoservices-secure.lib.berkeley.edu',
       geoserver_url: 'https://geoservices.lib.berkeley.edu/geoserver',
@@ -15,10 +12,9 @@ module Gingr
     # dirname where all geofile related ingestion files located inside the ingestion zipfile
     @geofile_ingestion_dirname = 'ingestion_files'
 
-    @logger = BerkeleyLibrary::Logging::Loggers.new_readable_logger(STDOUT)
-
     class << self
-      attr_accessor :reference_urls, :geofile_ingestion_dirname, :logger
+      attr_accessor :geofile_ingestion_dirname
+      attr_accessor :reference_urls
 
       include Config
     end

--- a/lib/gingr/data_handler.rb
+++ b/lib/gingr/data_handler.rb
@@ -3,10 +3,12 @@ require 'fileutils'
 require 'pathname'
 require 'zip'
 require_relative 'config'
+require_relative 'logging'
 
 module Gingr
   module DataHandler
-    include Gingr::Config
+    include Config
+    include Logging
 
     @spatial_root = ''
     @geoserver_root = ''
@@ -59,7 +61,7 @@ module Gingr
         FileUtils.rm_r(subdir_path) if File.directory? subdir_path
         subdir_path
       rescue Errno::EACCES
-        Config.logger.error("Permission denied: #{subdir_path}")
+        logger.error("Permission denied: #{subdir_path}")
         raise
       end
 

--- a/lib/gingr/geoserver_publisher.rb
+++ b/lib/gingr/geoserver_publisher.rb
@@ -1,16 +1,19 @@
 # frozen_string_literal: true
 require 'geoserver/publish'
 require 'uri'
-require_relative 'config'
+require_relative 'logging'
 
 module Gingr
   class GeoserverPublisher
-    include Gingr::Config
+    include Logging
 
     def initialize(url)
       uri = URI(url)
-      @conn = Geoserver::Publish::Connection.new({ 'url' => rest_url(uri), 'user' => uri.user,
-                                                   'password' => uri.password.to_s })
+      @conn = Geoserver::Publish::Connection.new({
+        'url' => rest_url(uri),
+        'user' => uri.user,
+        'password' => uri.password.to_s,
+      })
     end
 
     def update(filename)
@@ -18,7 +21,7 @@ module Gingr
       filepath = "file:///srv/geofiles/berkeley-#{name}/#{filename}"
       File.extname(filename).downcase == '.shp' ? publish_shapefile(filepath, name) : pulsih_geotiff(filepath, name)
     rescue Geoserver::Publish::Error => e
-      Config.logger.error("Publish Geoserver error: #{filename} -- #{e.inspect}")
+      logger.error("Publish Geoserver error: #{filename} -- #{e.inspect}")
       raise
     end
 

--- a/lib/gingr/import_util.rb
+++ b/lib/gingr/import_util.rb
@@ -3,11 +3,13 @@ require 'find'
 require 'uri'
 require_relative 'config'
 require_relative 'geoserver_publisher'
+require_relative 'logging'
 require_relative 'solr_indexer'
 
 module Gingr
   module ImportUtil
-    include Gingr::Config
+    include Config
+    include Logging
 
     class << self
       def publish_geoservers(geofile_names, options)
@@ -22,7 +24,7 @@ module Gingr
 
           indexer.update(path)
         rescue RSolr::Error::Http => e
-          Config.logger.error("Solr index error: #{e.response}")
+          logger.error("Solr index error: #{e.response}")
           raise
         end
         indexer.commit

--- a/lib/gingr/logging.rb
+++ b/lib/gingr/logging.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+require 'berkeley_library/logging'
+
+module Gingr
+  module Logging
+    class << self
+      def logger
+        @logger ||= BerkeleyLibrary::Logging::Loggers.new_readable_logger(STDOUT)
+      end
+    end
+
+    def logger
+      Logging.logger
+    end
+  end
+end

--- a/spec/solr_indexer_spec.rb
+++ b/spec/solr_indexer_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Gingr::SolrIndexer do
       end
 
       it 'should call the update reference field method' do
-        expect(solr_indexer.need_update_reference_urls).to eq(true)
+        expect(solr_indexer.update_reference_urls?).to eq(true)
       end
     end
 
@@ -54,7 +54,7 @@ RSpec.describe Gingr::SolrIndexer do
       let(:solr_indexer) { described_class.new(url) }
       it 'should not call the update reference field method' do
         solr_indexer.update(file_path)
-        expect(solr_indexer.need_update_reference_urls).to eq(false)
+        expect(solr_indexer.update_reference_urls?).to eq(false)
       end
     end
   end


### PR DESCRIPTION
Extracts logging, which was previously part of the Config module, into its own module per our usual patterns. Including classes can now access the `logger` directly without needing to namespace with `Config.logger` or `Logging.logger`.