### PR TITLE
Fixes option passing in the watcher command

### DIFF
--- a/lib/gingr/cli.rb
+++ b/lib/gingr/cli.rb
@@ -23,7 +23,7 @@ module Gingr
     option :geoserver_secure_url
     def watch(root_dir = nil)
       root_dir ||= ENV['GINGR_WATCH_DIRECTORY'] || '/opt/app/data/gingr'
-      watcher = Gingr::Watcher.new(root_dir, *options)
+      watcher = Gingr::Watcher.new(root_dir, options)
       watcher.start!
     end
 


### PR DESCRIPTION
The Watcher receives options as a hash parsed by Thor, but needs to pass them back to the system call as standard string CLI arguments. This commit adds a new `arguments` method which converts from the options hash to an array of option/values in sequence.