### PR TITLE
Draft: Ap 253: update rubyzip to 3.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'faraday-net_http_persistent', '~> 2.0'
 gem 'geo_combine'
 gem 'geoserver-publish', '~> 0.7.0'
 gem 'rsolr'
-gem 'rubyzip'
+gem 'rubyzip', '3.0.0.alpha'
 gem "berkeley_library-docker", "~> 0.2.0"
 gem "listen", "~> 3.8"
 gem 'uri'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,7 +162,7 @@ GEM
       rspec-support (~> 3.12.0)
     rspec-support (3.12.1)
     ruby2_keywords (0.0.5)
-    rubyzip (2.3.2)
+    rubyzip (3.0.0.alpha)
     sanitize (6.1.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -189,7 +189,7 @@ DEPENDENCIES
   pry (~> 0.14.2)
   rsolr
   rspec (~> 3.12)
-  rubyzip
+  rubyzip (= 3.0.0.alpha)
   uri
 
 RUBY VERSION

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,14 +39,14 @@ services:
       - ./data/spatial:/usr/local/apache2/htdocs/:ro
 
   geoserver:
-    image: containers.lib.berkeley.edu/gis/geoserver/v2.23.2
+    image: containers.lib.berkeley.edu/gis/geoserver:latest
     ports:
       - 8080:8080
     volumes:
       - ./data/geoserver/public:/srv/geofiles:delegated
 
   geoserver-secure:
-    image: containers.lib.berkeley.edu/gis/geoserver/v2.23.2
+    image: containers.lib.berkeley.edu/gis/geoserver:latest
     ports:
       - 8081:8080
     volumes:

--- a/lib/gingr/cli.rb
+++ b/lib/gingr/cli.rb
@@ -80,13 +80,7 @@ module Gingr
     option :geoserver_root
     def unpack(zipfile)
       zipfile_path = zipfile == File.basename(zipfile) ? File.join(ImportUtil.root_path, 'import', zipfile) : zipfile
-      DataHandler.spatial_root = options[:spatial_root] || ENV.fetch('SPATIAL_ROOT',
-                                                                     Config.default_options[:spatial_root])
-      DataHandler.geoserver_root = options[:geoserver_root] || ENV.fetch('GEOSERVER_ROOT',
-                                                                         Config.default_options[:geoserver_root])
-
-      gingr_watch_root_dir ||= ENV['GINGR_WATCH_DIRECTORY'] || '/opt/app/data/gingr'
-      DataHandler.processing_root = File.join(gingr_watch_root_dir, 'processing')
+      set_data_handler(options[:spatial_root], options[:geoserver_root])
       DataHandler.extract_and_move(zipfile_path)
     end
 
@@ -107,12 +101,13 @@ module Gingr
     option :geoserver_secure_url
     def all(zipfile)
       unpacked = unpack(zipfile)
-      solr(unpacked[:extract_to_path])
+      total_indexed = solr(unpacked[:extract_to_path])
 
       geofile_names = unpacked[:geofile_name_hash]
       geoserver_urls = options.slice(:geoserver_url, :geoserver_secure_url).transform_keys(&:to_sym)
-      Gingr::GeoserverPublisher.publish_inventory(geofile_names, **geoserver_urls)
-      logger.info("#{zipfile} - all imported")
+      failed_files = Gingr::GeoserverPublisher.publish_inventory(geofile_names, **geoserver_urls)
+
+      report(total_indexed, failed_files, zipfile)
     end
 
     desc 'geoserver_workspace', 'create a workspace in a geoserver'
@@ -125,6 +120,30 @@ module Gingr
       default = options[:is_public] ? :geoserver_url : :geoserver_secure_url
       publisher = GeoserverPublisher.new(options[:geoserver_url], default:, workspace_name:)
       publisher.create_workspace
+    end
+
+    private
+
+    def set_data_handler(spatial_root, goserver_root)
+      DataHandler.spatial_root = spatial_root || ENV.fetch('SPATIAL_ROOT',
+                                                           Config.default_options[:spatial_root])
+      DataHandler.geoserver_root = goserver_root || ENV.fetch('GEOSERVER_ROOT',
+                                                              Config.default_options[:geoserver_root])
+      gingr_watch_root_dir ||= ENV['GINGR_WATCH_DIRECTORY'] || '/opt/app/data/gingr'
+      DataHandler.processing_root = File.join(gingr_watch_root_dir, 'processing')
+    end
+
+    def report(total_indexed, failed_files, zipfile)
+      if total_indexed.nil?
+        logger.error('Solr indexing failed')
+        logger.info("#{zipfile} - not imported")
+        return
+      end
+      logger.info("#{zipfile} - all imported, total records: #{total_indexed}")
+      return if failed_files.empty?
+
+      logger.warn("#{zipfile} - some shapefile or GeoTIFF files not published to Geoservers")
+      logger.error("Failed to published geo files: #{failed_files.join('; ')}")
     end
   end
 end

--- a/lib/gingr/geoserver_publisher.rb
+++ b/lib/gingr/geoserver_publisher.rb
@@ -11,21 +11,24 @@ module Gingr
     DEFAULT_REMOTE_ROOT = '/srv/geofiles'
     DEFAULT_WORKSPACE = 'UCB'
 
-    attr_reader :connection
-    attr_reader :remote_root
-    attr_reader :workspace_name
+    attr_reader :connection, :remote_root, :workspace_name
 
     class << self
       def publish_inventory(inventory, geoserver_url: nil, geoserver_secure_url: nil)
-        if !inventory[:public].empty?
+        public_files = inventory[:public_files]
+        ucb_files = inventory[:ucb_files]
+        un_published_shapefiles = []
+        un_published_geotiffs = []
+        unless public_files.empty?
           public_publisher = new(geoserver_url)
-          public_publisher.batch_publish(inventory[:public])
+          un_published_shapefiles = public_publisher.batch_publish(public_files)
         end
 
-        if !inventory[:ucb].empty?
+        unless ucb_files.empty?
           secure_publisher = new(geoserver_secure_url, default: :geoserver_secure_url)
-          secure_publisher.batch_publish(inventory[:ucb])
+          un_published_geotiffs = secure_publisher.batch_publish(ucb_files)
         end
+        (un_published_shapefiles + un_published_geotiffs).compact
       end
 
       def parse_connection_string(geoserver_baseurl)
@@ -39,7 +42,7 @@ module Gingr
           port: uri.port == uri.default_port ? nil : uri.port,
           path: uri.path,
           fragment: uri.fragment,
-          query: uri.query,
+          query: uri.query
         ).to_s, uri.user, uri.password
       end
     end
@@ -63,17 +66,15 @@ module Gingr
     end
 
     def batch_publish(filenames)
-      filenames.each(&method(:publish))
+      filenames.map(&method(:publish))
     end
-
+    
     def publish(filename)
       id = File.basename(filename, '.*')
       file_path = remote_filepath(id, filename)
-      if File.extname(filename).casecmp?('.shp')
-        publish_shapefile(file_path, id)
-      else
-        publish_geotiff(file_path, id)
-      end
+      return publish_shapefile(file_path, id) if File.extname(filename).casecmp?('.shp')
+
+      publish_geotiff(file_path, id)
     end
 
     def create_workspace
@@ -92,11 +93,19 @@ module Gingr
     def publish_shapefile(file_path, id)
       logger.debug("Publishing shapefile #{id} to #{geoserver_url}")
       Geoserver::Publish.shapefile(connection:, workspace_name:, file_path:, id:, title: id)
+      nil
+    rescue StandardError => e
+      logger.error("Error publishing shapefile #{file_path} to #{geoserver_url}: #{e.message}")
+      file_path
     end
 
     def publish_geotiff(file_path, id)
       logger.debug("Publishing geotiff #{id} to #{geoserver_url}")
       Geoserver::Publish.geotiff(connection:, workspace_name:, file_path:, id:, title: id)
+      nil
+    rescue StandardError => e
+      logger.error("Error publishing GeoTIFF #{file_path} to #{geoserver_url}: #{e.message}")
+      file_path
     end
 
     def remote_filepath(id, filename)

--- a/spec/geoserver_publisher_spec.rb
+++ b/spec/geoserver_publisher_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Gingr::GeoserverPublisher do
       Gingr::DataHandler.geoserver_root = '/opt/app/data/geoserver'
       Gingr::DataHandler.extract_and_move('spec/fixture/zipfile/vector_restricted_with_attachment.zip')
       Gingr::DataHandler.extract_and_move('spec/fixture/zipfile/vector.zip')
-      # Gingr::DataHandler.extract_and_move('spec/fixture/zipfile/raster_public.zip')
+      Gingr::DataHandler.extract_and_move('spec/fixture/zipfile/raster_public.zip')
       test.run
     ensure
       workspace_client.delete(workspace_name:)
@@ -126,7 +126,7 @@ RSpec.describe Gingr::GeoserverPublisher do
         subject.batch_publish %w(fk4hm6vj5q.shp fk4cv64r2x.shp)
       end
 
-      !it 'publishes a raster file' do
+      it 'publishes a raster file' do
         # pending 'Missing datafile'
         subject.publish 'fk4mk7zb4q.tif'
       end

--- a/spec/geoserver_publisher_spec.rb
+++ b/spec/geoserver_publisher_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Gingr::GeoserverPublisher do
       Gingr::DataHandler.geoserver_root = '/opt/app/data/geoserver'
       Gingr::DataHandler.extract_and_move('spec/fixture/zipfile/vector_restricted_with_attachment.zip')
       Gingr::DataHandler.extract_and_move('spec/fixture/zipfile/vector.zip')
-      Gingr::DataHandler.extract_and_move('spec/fixture/zipfile/raster_public.zip')
+      # Gingr::DataHandler.extract_and_move('spec/fixture/zipfile/raster_public.zip')
       test.run
     ensure
       workspace_client.delete(workspace_name:)
@@ -126,7 +126,7 @@ RSpec.describe Gingr::GeoserverPublisher do
         subject.batch_publish %w(fk4hm6vj5q.shp fk4cv64r2x.shp)
       end
 
-      it 'publishes a raster file' do
+      !it 'publishes a raster file' do
         # pending 'Missing datafile'
         subject.publish 'fk4mk7zb4q.tif'
       end

--- a/spec/geoserver_publisher_spec.rb
+++ b/spec/geoserver_publisher_spec.rb
@@ -106,8 +106,12 @@ RSpec.describe Gingr::GeoserverPublisher do
 
     around do |test|
       workspace_client.create(workspace_name:)
+      Gingr::DataHandler.processing_root = '/opt/app/tmp'
+      Gingr::DataHandler.spatial_root = '/opt/app/data/spatial'
+      Gingr::DataHandler.geoserver_root = '/opt/app/data/geoserver'
       Gingr::DataHandler.extract_and_move('spec/fixture/zipfile/vector_restricted_with_attachment.zip')
       Gingr::DataHandler.extract_and_move('spec/fixture/zipfile/vector.zip')
+      # Gingr::DataHandler.extract_and_move('spec/fixture/zipfile/raster_public.zip')
       test.run
     ensure
       workspace_client.delete(workspace_name:)
@@ -122,9 +126,9 @@ RSpec.describe Gingr::GeoserverPublisher do
         subject.batch_publish %w(fk4hm6vj5q.shp fk4cv64r2x.shp)
       end
 
-      it 'publishes a raster file' do
-        pending 'Missing datafile'
-        subject.publish '{TO BE CREATED}.rst'
+      !it 'publishes a raster file' do
+        # pending 'Missing datafile'
+        subject.publish 'fk4mk7zb4q.tif'
       end
     end
 

--- a/spec/geoserver_publisher_spec.rb
+++ b/spec/geoserver_publisher_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Gingr::GeoserverPublisher do
       Gingr::DataHandler.geoserver_root = '/opt/app/data/geoserver'
       Gingr::DataHandler.extract_and_move('spec/fixture/zipfile/vector_restricted_with_attachment.zip')
       Gingr::DataHandler.extract_and_move('spec/fixture/zipfile/vector.zip')
-      # Gingr::DataHandler.extract_and_move('spec/fixture/zipfile/raster_public.zip')
+      Gingr::DataHandler.extract_and_move('spec/fixture/zipfile/raster_public.zip')
       test.run
     ensure
       workspace_client.delete(workspace_name:)
@@ -119,16 +119,15 @@ RSpec.describe Gingr::GeoserverPublisher do
 
     context 'with a public geoserver' do
       it 'publishes a shapefile' do
-        subject.publish 'fk4hm6vj5q.shp'
+        expect(subject.publish('fk4hm6vj5q.shp')).to be_nil
       end
 
       it 'publishes a batch of shapefiles' do
-        subject.batch_publish %w(fk4hm6vj5q.shp fk4cv64r2x.shp)
+        expect(subject.batch_publish(%w[fk4hm6vj5q.shp fk4cv64r2x.shp])).to all(be_nil)
       end
 
-      !it 'publishes a raster file' do
-        # pending 'Missing datafile'
-        subject.publish 'fk4mk7zb4q.tif'
+      it 'publishes a raster file' do
+        expect(subject.publish('fk4mk7zb4q.tif')).to be_nil
       end
     end
 
@@ -136,7 +135,7 @@ RSpec.describe Gingr::GeoserverPublisher do
       let(:default) { :geoserver_secure_url }
 
       it 'publishes a shapefile' do
-        subject.publish 's76412.shp'
+        expect(subject.publish('s76412.shp')).to be_nil
       end
     end
   end


### PR DESCRIPTION
1. Update rubyzip to version 3.0.0 and related code
2. Enhance datahandler.rb to log data extraction and file movement information
3. Modify geoserver_publisher.spec to ensure publish examples pass
4. Refine code and add logging for more Solr indexing and Geoserver publishing information
5. Created a small raster.zip(88MB) for testing Geoserver raster publishing, but encountered a Git commit warning due to file size. It has been excluded. A new version under 50MB will needed to be created
6. Created a smaller raster_public.zip file in 41MB